### PR TITLE
Budget report with warnings and budget allocation/shifting

### DIFF
--- a/client/src/components/dashboard/Budget/BudgetReporting.jsx
+++ b/client/src/components/dashboard/Budget/BudgetReporting.jsx
@@ -1,16 +1,59 @@
 import React from "react";
 import { aud } from "../utils/formatters";
 
+function Badge({ level, children }) {
+  const style = {
+    display: "inline-block",
+    padding: "2px 8px",
+    borderRadius: 12,
+    fontSize: 12,
+    marginLeft: 6,
+    background:
+      level === "serious"
+        ? "#fee2e2"
+        : level === "medium"
+        ? "#fef3c7"
+        : level === "light"
+        ? "#e0f2fe"
+        : "#eee",
+    color:
+      level === "serious"
+        ? "#991b1b"
+        : level === "medium"
+        ? "#92400e"
+        : level === "light"
+        ? "#075985"
+        : "#444",
+  };
+  return <span style={style}>{children}</span>;
+}
+
 function BudgetReporting({ jwt, clients }) {
   const [reportClientId, setReportClientId] = React.useState("");
   const [reportYear, setReportYear] = React.useState(new Date().getFullYear());
   const [report, setReport] = React.useState(null);
   const [reportErr, setReportErr] = React.useState("");
+  const [loading, setLoading] = React.useState(false);
+
+  // Which categories are expanded
+  const [openCats, setOpenCats] = React.useState({}); // { [category]: boolean }
+
+  // Inline budget editor state: { [itemId]: { editing: boolean, draft: string, saving: boolean, err?: string } }
+  const [editByItem, setEditByItem] = React.useState({});
+
+  // NEW: predefined client budget inline editor
+  const [editPredef, setEditPredef] = React.useState({
+    editing: false,
+    draft: "",
+    saving: false,
+    err: "",
+  });
 
   const loadBudgetReport = async () => {
     try {
       setReportErr("");
       setReport(null);
+      setLoading(true);
       if (!jwt) throw new Error("UNAUTHENTICATED");
       if (!reportClientId) throw new Error("Please choose a client");
 
@@ -18,21 +61,152 @@ function BudgetReporting({ jwt, clients }) {
         `/api/reports/budget?personId=${encodeURIComponent(
           reportClientId
         )}&year=${encodeURIComponent(reportYear)}`,
-        {
-          headers: { Authorization: "Bearer " + jwt },
-        }
+        { headers: { Authorization: "Bearer " + jwt } }
       );
       const d = await r.json();
       if (!r.ok) throw new Error(d.error || "Failed to load report");
       setReport(d);
     } catch (e) {
       setReportErr(e.message || String(e));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const toggleCat = (cat) => setOpenCats((p) => ({ ...p, [cat]: !p[cat] }));
+
+  const startEdit = (itemId, currentAmount) => {
+    setEditByItem((p) => ({
+      ...p,
+      [itemId]: {
+        editing: true,
+        draft:
+          currentAmount !== undefined && currentAmount !== null
+            ? String(currentAmount)
+            : "",
+        saving: false,
+        err: "",
+      },
+    }));
+  };
+
+  const cancelEdit = (itemId) => {
+    setEditByItem((p) => ({
+      ...p,
+      [itemId]: { editing: false, draft: "", saving: false, err: "" },
+    }));
+  };
+
+  const changeDraft = (itemId, value) => {
+    setEditByItem((p) => ({
+      ...p,
+      [itemId]: { ...(p[itemId] || {}), draft: value },
+    }));
+  };
+
+  const saveBudget = async (itemId) => {
+    const row = editByItem[itemId];
+    if (!row) return;
+    try {
+      if (!jwt) throw new Error("UNAUTHENTICATED");
+      const amt = Number(row.draft);
+      if (!Number.isFinite(amt) || amt < 0) {
+        throw new Error("Please enter a non-negative number.");
+      }
+
+      setEditByItem((p) => ({
+        ...p,
+        [itemId]: { ...row, saving: true, err: "" },
+      }));
+
+      // PATCH per-year budget for this item
+      const r = await fetch(
+        `/api/care-need-items/${encodeURIComponent(
+          itemId
+        )}/budgets/${encodeURIComponent(reportYear)}`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer " + jwt,
+          },
+          body: JSON.stringify({ amount: amt }),
+        }
+      );
+      const d = await r.json();
+      if (!r.ok) throw new Error(d.error || "Failed to update budget");
+
+      // After success, close editor and refresh report so rollups update
+      setEditByItem((p) => ({
+        ...p,
+        [itemId]: { editing: false, draft: "", saving: false, err: "" },
+      }));
+      await loadBudgetReport();
+    } catch (e) {
+      setEditByItem((p) => ({
+        ...p,
+        [itemId]: {
+          ...(p[itemId] || {}),
+          saving: false,
+          err: e.message || String(e),
+        },
+      }));
+    }
+  };
+  const beginEditPredef = () => {
+    setEditPredef({
+      editing: true,
+      draft:
+        report && report.predefinedAnnualBudget != null
+          ? String(report.predefinedAnnualBudget)
+          : "",
+      saving: false,
+      err: "",
+    });
+  };
+  const cancelEditPredef = () =>
+    setEditPredef({ editing: false, draft: "", saving: false, err: "" });
+
+  const savePredefBudget = async () => {
+    try {
+      if (!jwt) throw new Error("UNAUTHENTICATED");
+      if (!reportClientId) throw new Error("No client selected.");
+      const amt = Number(editPredef.draft);
+      if (!Number.isFinite(amt) || amt < 0)
+        throw new Error("Please enter a non-negative number.");
+
+      setEditPredef((p) => ({ ...p, saving: true, err: "" }));
+
+      const r = await fetch(
+        `/api/person-with-needs/${encodeURIComponent(reportClientId)}/budget`,
+        {
+          method: "PATCH",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: "Bearer " + jwt,
+          },
+          body: JSON.stringify({ amount: amt }),
+        }
+      );
+      const d = await r.json();
+      if (!r.ok) throw new Error(d.error || "Failed to update client budget");
+
+      // refresh the report so warnings/comparisons update
+      await loadBudgetReport();
+      setEditPredef({ editing: false, draft: "", saving: false, err: "" });
+    } catch (e) {
+      setEditPredef((p) => ({
+        ...p,
+        saving: false,
+        err: e.message || String(e),
+      }));
     }
   };
 
   return (
     <div className="card">
       <h3>Budget Reporting</h3>
+
       <div className="row">
         <div>
           <label>Client</label>
@@ -59,25 +233,85 @@ function BudgetReporting({ jwt, clients }) {
           />
         </div>
       </div>
-      <button onClick={loadBudgetReport}>Run report</button>
+
+      <button onClick={loadBudgetReport} disabled={loading}>
+        {loading ? "Running…" : "Run report"}
+      </button>
       {reportErr && <p style={{ color: "#b91c1c" }}>Error: {reportErr}</p>}
 
       {report && (
         <div style={{ marginTop: 12 }}>
           <p>
-            <strong>Annual budget:</strong> {aud.format(report.annualBudget)}
+            {/* Predefined client budget with inline editor */}
+            <strong>Client’s predefined annual budget:</strong>{" "}
+            {!editPredef.editing ? (
+              <>
+                {aud.format(report.predefinedAnnualBudget || 0)}{" "}
+                {report.warnings?.budgetVsPredefined && (
+                  <Badge level={report.warnings.budgetVsPredefined.level}>
+                    {report.warnings.budgetVsPredefined.message}
+                  </Badge>
+                )}
+                <button
+                  className="secondary"
+                  style={{ marginLeft: 8 }}
+                  onClick={beginEditPredef}
+                >
+                  Edit predefined annual budget
+                </button>
+              </>
+            ) : (
+              <span style={{ display: "inline-flex", gap: 6, marginLeft: 6 }}>
+                <input
+                  type="number"
+                  min="0"
+                  step="0.01"
+                  value={editPredef.draft}
+                  onChange={(e) =>
+                    setEditPredef((p) => ({ ...p, draft: e.target.value }))
+                  }
+                  style={{ width: 140 }}
+                />
+                <button onClick={savePredefBudget} disabled={editPredef.saving}>
+                  {editPredef.saving ? "Saving…" : "Save"}
+                </button>
+                <button
+                  className="secondary"
+                  onClick={cancelEditPredef}
+                  disabled={editPredef.saving}
+                >
+                  Cancel
+                </button>
+                {editPredef.err && (
+                  <span style={{ color: "#b91c1c" }}>{editPredef.err}</span>
+                )}
+              </span>
+            )}
+            <br />
+            <strong>Annual budget (sum of categories):</strong>{" "}
+            {aud.format(report.annualBudget)}
             <br />
             <strong>Already spent:</strong> {aud.format(report.spent.total)}{" "}
             <span style={{ opacity: 0.7 }}>
               (purchase {aud.format(report.spent.purchase)} + completed tasks{" "}
               {aud.format(report.spent.completed)})
-            </span>
+            </span>{" "}
+            {report.warnings?.spentVsReportBudget && (
+              <Badge level={report.warnings.spentVsReportBudget.level}>
+                {report.warnings.spentVsReportBudget.message}
+              </Badge>
+            )}
             <br />
             <strong>Current balance:</strong>{" "}
             {aud.format(report.balance.current)}
             <br />
             <strong>Expected remaining (uncompleted tasks):</strong>{" "}
-            {aud.format(report.expected.remaining)}
+            {aud.format(report.expected.remaining)}{" "}
+            {report.warnings?.projectedVsReportBudget && (
+              <Badge level={report.warnings.projectedVsReportBudget.level}>
+                {report.warnings.projectedVsReportBudget.message}
+              </Badge>
+            )}
             <br />
             <strong>Expected balance at year end:</strong>{" "}
             {aud.format(report.balance.expectedAtYearEnd)}
@@ -91,41 +325,200 @@ function BudgetReporting({ jwt, clients }) {
               <thead>
                 <tr>
                   <th style={{ textAlign: "left" }}>Category</th>
-                  <th style={{ textAlign: "right" }}>Annual Budget</th>
-                  <th style={{ textAlign: "right" }}>Already Spent</th>
-                  <th style={{ textAlign: "right" }}>Current Balance</th>
-                  <th style={{ textAlign: "right" }}>Expected Remaining</th>
-                  <th style={{ textAlign: "right" }}>Expected Balance</th>
-                  <th style={{ textAlign: "right" }}>% Spent</th>
-                  <th style={{ textAlign: "right" }}>% Expected</th>
+                  <th style={{ textAlign: "left" }}>Annual Budget</th>
+                  <th style={{ textAlign: "left" }}>Already Spent</th>
+                  <th style={{ textAlign: "left" }}>Current Balance</th>
+                  <th style={{ textAlign: "left" }}>Expected Remaining</th>
+                  <th style={{ textAlign: "left" }}>Expected Balance</th>
+                  <th style={{ textAlign: "left" }}>% Spent</th>
+                  <th style={{ textAlign: "left" }}>% Expected</th>
+                  <th style={{ textAlign: "left" }}>Details</th>
                 </tr>
               </thead>
               <tbody>
                 {report.categories.map((c) => (
-                  <tr key={c.category}>
-                    <td>{c.category}</td>
-                    <td style={{ textAlign: "right" }}>
-                      {aud.format(c.annualBudget || 0)}
-                    </td>
-                    <td style={{ textAlign: "right" }}>
-                      {aud.format(c.totalSpent || 0)}
-                    </td>
-                    <td style={{ textAlign: "right" }}>
-                      {aud.format(c.currentBalance || 0)}
-                    </td>
-                    <td style={{ textAlign: "right" }}>
-                      {aud.format(c.expected || 0)}
-                    </td>
-                    <td style={{ textAlign: "right" }}>
-                      {aud.format(c.expectedBalanceAtYearEnd || 0)}
-                    </td>
-                    <td style={{ textAlign: "right" }}>
-                      {((c.spentPct || 0) * 100).toFixed(1)}%
-                    </td>
-                    <td style={{ textAlign: "right" }}>
-                      {((c.expectedPct || 0) * 100).toFixed(1)}%
-                    </td>
-                  </tr>
+                  <React.Fragment key={c.category}>
+                    <tr>
+                      <td>{c.category}</td>
+                      <td>{aud.format(c.annualBudget || 0)}</td>
+                      <td>{aud.format(c.totalSpent || 0)}</td>
+                      <td>{aud.format(c.currentBalance || 0)}</td>
+                      <td>{aud.format(c.expected || 0)}</td>
+                      <td>{aud.format(c.expectedBalanceAtYearEnd || 0)}</td>
+                      <td>{((c.spentPct || 0) * 100).toFixed(1)}%</td>
+                      <td>{((c.expectedPct || 0) * 100).toFixed(1)}%</td>
+                      <td>
+                        <button
+                          className="secondary"
+                          onClick={() => toggleCat(c.category)}
+                        >
+                          {openCats[c.category] ? "Hide" : "Show"}
+                        </button>
+                      </td>
+                    </tr>
+
+                    {openCats[c.category] && (
+                      <tr>
+                        <td
+                          colSpan={9}
+                          style={{ background: "#fafafa", padding: 8 }}
+                        >
+                          {!c.items || c.items.length === 0 ? (
+                            <div style={{ opacity: 0.7 }}>
+                              No items for this category in {report.year}.
+                            </div>
+                          ) : (
+                            <table
+                              style={{
+                                width: "100%",
+                                borderCollapse: "collapse",
+                              }}
+                            >
+                              <thead>
+                                <tr>
+                                  <th style={{ textAlign: "left" }}>
+                                    Care need item
+                                  </th>
+                                  <th style={{ textAlign: "left" }}>
+                                    Annual Budget
+                                  </th>
+                                  <th style={{ textAlign: "left" }}>
+                                    Already Spent
+                                  </th>
+                                  <th style={{ textAlign: "left" }}>
+                                    Current Balance
+                                  </th>
+                                  <th style={{ textAlign: "left" }}>
+                                    Expected Remaining
+                                  </th>
+                                  <th style={{ textAlign: "left" }}>
+                                    Expected Balance
+                                  </th>
+                                  <th style={{ textAlign: "left" }}>Warning</th>
+                                  <th style={{ textAlign: "left" }}>Actions</th>
+                                </tr>
+                              </thead>
+                              <tbody>
+                                {c.items.map((it) => {
+                                  const ed = editByItem[it.itemId];
+                                  const isEditing = !!ed?.editing;
+                                  const saving = !!ed?.saving;
+                                  return (
+                                    <tr
+                                      key={it.itemId}
+                                      style={{ borderTop: "1px solid #eee" }}
+                                    >
+                                      <td>{it.name}</td>
+
+                                      <td>
+                                        {isEditing ? (
+                                          <div
+                                            style={{
+                                              display: "flex",
+                                              gap: 6,
+                                              alignItems: "center",
+                                            }}
+                                          >
+                                            <input
+                                              type="number"
+                                              min="0"
+                                              step="0.01"
+                                              value={ed.draft}
+                                              onChange={(e) =>
+                                                changeDraft(
+                                                  it.itemId,
+                                                  e.target.value
+                                                )
+                                              }
+                                              style={{ width: 120 }}
+                                            />
+                                            <button
+                                              onClick={() =>
+                                                saveBudget(it.itemId)
+                                              }
+                                              disabled={saving}
+                                            >
+                                              {saving ? "Saving…" : "Save"}
+                                            </button>
+                                            <button
+                                              className="secondary"
+                                              onClick={() =>
+                                                cancelEdit(it.itemId)
+                                              }
+                                              disabled={saving}
+                                            >
+                                              Cancel
+                                            </button>
+                                          </div>
+                                        ) : (
+                                          <strong>
+                                            {aud.format(it.annualBudget || 0)}
+                                          </strong>
+                                        )}
+                                        {ed?.err && (
+                                          <div
+                                            style={{
+                                              color: "#b91c1c",
+                                              marginTop: 4,
+                                            }}
+                                          >
+                                            {ed.err}
+                                          </div>
+                                        )}
+                                      </td>
+
+                                      <td>
+                                        {aud.format(it.alreadySpent || 0)}
+                                      </td>
+                                      <td>
+                                        {aud.format(it.currentBalance || 0)}
+                                      </td>
+                                      <td>
+                                        {aud.format(it.expectedRemaining || 0)}
+                                      </td>
+                                      <td>
+                                        {aud.format(
+                                          it.expectedBalanceAtYearEnd || 0
+                                        )}
+                                      </td>
+
+                                      <td>
+                                        {it.warning ? (
+                                          <Badge level={it.warning.level}>
+                                            {it.warning.message}
+                                          </Badge>
+                                        ) : (
+                                          <span style={{ opacity: 0.6 }}>
+                                            —
+                                          </span>
+                                        )}
+                                      </td>
+
+                                      <td>
+                                        {!isEditing && (
+                                          <button
+                                            className="secondary"
+                                            onClick={() =>
+                                              startEdit(
+                                                it.itemId,
+                                                it.annualBudget || 0
+                                              )
+                                            }
+                                          >
+                                            Edit budget
+                                          </button>
+                                        )}
+                                      </td>
+                                    </tr>
+                                  );
+                                })}
+                              </tbody>
+                            </table>
+                          )}
+                        </td>
+                      </tr>
+                    )}
+                  </React.Fragment>
                 ))}
               </tbody>
             </table>

--- a/client/src/components/dashboard/CareNeedItems/Create.jsx
+++ b/client/src/components/dashboard/CareNeedItems/Create.jsx
@@ -233,7 +233,7 @@ function Create({ jwt, clients }) {
 
   return (
     <div className="card">
-      <h3>Create Care Need Item</h3>
+      <h3>Create Care Need Item (Sub-element)</h3>
       <form onSubmit={submitCareNeedItem}>
         <label>Client</label>
         <select

--- a/server/routes/careNeedItem.js
+++ b/server/routes/careNeedItem.js
@@ -6,6 +6,7 @@ import {
   requireRole,
   ensureCanManagePerson,
 } from "../middleware/authz.js";
+import mongoose from "mongoose";
 
 const router = Router();
 
@@ -47,8 +48,8 @@ async function createItem(req, res) {
       personId,
       name,
       description,
-      category, // may be "Other" or any predefined/custom
-      newCategoryName, // optional: custom category typed by user
+      category,
+      newCategoryName,
       frequency,
       endDate,
       occurrenceCount,
@@ -59,22 +60,16 @@ async function createItem(req, res) {
       timeWindow,
     } = req.body;
 
-    // Load person to derive org & validate scope
+    // Validate person & org scope
     const person = await PersonWithNeeds.findById(personId).select(
-      "organizationId"
+      "organizationId customCategories"
     );
     if (!person) return res.status(400).json({ error: "INVALID_PERSON" });
-
-    // Optional: role guard (only Family/Admin can create)
-    if (!["Family", "Admin", "PoA"].includes(req.user.role)) {
-      return res.status(403).json({ error: "FORBIDDEN" });
-    }
-    // Optional: ensure caller is same org as the person
     if (String(person.organizationId) !== String(req.user.organizationId)) {
       return res.status(403).json({ error: "ORG_SCOPE_INVALID" });
     }
 
-    // Validate scheduleType/timeWindow
+    // ScheduleType/timeWindow validation
     const st = scheduleType === "Timed" ? "Timed" : "AllDay";
     let tw;
     if (st === "Timed") {
@@ -93,7 +88,7 @@ async function createItem(req, res) {
       tw = { startTime: timeWindow.startTime, endTime: timeWindow.endTime };
     }
 
-    // Decide final category
+    // Final category (persist custom to person if new)
     let finalCategory =
       newCategoryName && newCategoryName.trim()
         ? newCategoryName.trim()
@@ -101,10 +96,6 @@ async function createItem(req, res) {
     if (!finalCategory)
       return res.status(400).json({ error: "CATEGORY_REQUIRED" });
 
-    // If new, persist into person's customCategories (case-insensitive uniqueness)
-    const existing = new Set(
-      (person.customCategories || []).map((s) => s.toLowerCase())
-    );
     const predefined = [
       "HygieneProducts",
       "Clothing",
@@ -112,9 +103,12 @@ async function createItem(req, res) {
       "Entertainment",
       "Other",
     ].map((s) => s.toLowerCase());
+    const existingCustom = new Set(
+      (person.customCategories || []).map((s) => s.toLowerCase())
+    );
     if (
-      !existing.has(finalCategory.toLowerCase()) &&
-      !predefined.includes(finalCategory.toLowerCase())
+      !predefined.includes(finalCategory.toLowerCase()) &&
+      !existingCustom.has(finalCategory.toLowerCase())
     ) {
       await PersonWithNeeds.updateOne(
         { _id: person._id },
@@ -122,7 +116,32 @@ async function createItem(req, res) {
       );
     }
 
-    // Create item (force organizationId from person)
+    // ——— Derive the year span for budgets[] ———
+    const start =
+      frequency?.intervalType === "JustPurchase"
+        ? new Date() // purchase-only: today
+        : frequency?.startDate
+        ? new Date(frequency.startDate)
+        : null;
+
+    const intervalType = frequency?.intervalType;
+    const intervalValue = Number(frequency?.intervalValue || 1);
+    const occCount = occurrenceCount ? Number(occurrenceCount) : null;
+    const hardEnd = endDate ? new Date(endDate) : null;
+
+    const lastDate = computeLastOccurrenceDate({
+      intervalType,
+      intervalValue,
+      startDate: start,
+      endDate: hardEnd,
+      occurrenceCount: occCount,
+    });
+
+    const years = deriveYearSetFromSpan(start, lastDate);
+    const amount = Number(budgetCost) || 0;
+    const budgets = Array.from(years).map((y) => ({ year: y, amount }));
+
+    // Create the item (budgets filled for span)
     const item = await CareNeedItem.create({
       personId,
       organizationId: person.organizationId,
@@ -130,9 +149,10 @@ async function createItem(req, res) {
       description,
       category: finalCategory,
       frequency,
-      endDate: endDate || null,
-      occurrenceCount: occurrenceCount || null,
-      budgetCost: Number(budgetCost) || 0,
+      endDate: hardEnd || null,
+      occurrenceCount: occCount || null,
+      budgetCost: amount, // keep legacy default
+      budgets, // NEW: per-year entries
       purchaseCost: Number(purchaseCost) || 0,
       occurrenceCost: Number(occurrenceCost) || 0,
       scheduleType: st,
@@ -146,6 +166,54 @@ async function createItem(req, res) {
     res.status(400).json({ error: e.message });
   }
 }
+
+/** Helpers **/
+
+function computeLastOccurrenceDate({
+  intervalType,
+  intervalValue,
+  startDate,
+  endDate,
+  occurrenceCount,
+}) {
+  // If purchase-only or missing start, no span => use start year only
+  if (!startDate) return startDate;
+
+  // 1) If explicit endDate is provided, trust it
+  if (endDate) return endDate;
+
+  // 2) If occurrenceCount is provided, compute last by stepping (occCount-1) intervals
+  if (occurrenceCount && occurrenceCount > 0) {
+    const steps = Math.max(occurrenceCount - 1, 0);
+    return stepDate(startDate, intervalType, intervalValue * steps);
+  }
+
+  // 3) Otherwise (no end condition): default to just the start year
+  //    (You can change this policy if you want a default horizon)
+  return startDate;
+}
+
+function stepDate(d0, t, n) {
+  const d = new Date(d0);
+  if (t === "Daily") d.setDate(d.getDate() + n);
+  if (t === "Weekly") d.setDate(d.getDate() + 7 * n);
+  if (t === "Monthly") d.setMonth(d.getMonth() + n);
+  if (t === "Yearly") d.setFullYear(d.getFullYear() + n);
+  // OneTime/JustPurchase: n should be 0; return same date
+  return d;
+}
+
+function deriveYearSetFromSpan(start, end) {
+  const set = new Set();
+  if (!start) return set;
+  const y1 = start.getUTCFullYear();
+  const y2 = end ? end.getUTCFullYear() : y1;
+  const low = Math.min(y1, y2);
+  const high = Math.max(y1, y2);
+  for (let y = low; y <= high; y++) set.add(y);
+  return set;
+}
+
 async function getItem(req, res) {
   const item = await CareNeedItem.findById(req.params.itemId).lean();
   if (!item) return res.status(404).json({ error: "Not found" });
@@ -186,5 +254,69 @@ async function deleteItem(req, res) {
   await CareNeedItem.deleteOne({ _id: req.params.itemId });
   res.json({ message: "Item deleted" });
 }
+
+/**
+ * PATCH /api/care-need-items/:itemId/budgets/:year
+ * Body: { amount: number }
+ * Upserts a single year budget inside CareNeedItem.budgets[]
+ */
+router.patch(
+  "/:itemId/budgets/:year",
+  requireAuth,
+  requireRole("Admin", "Family", "PoA"),
+  async (req, res) => {
+    try {
+      const { itemId, year } = req.params;
+      const { amount } = req.body || {};
+      const y = Number(year);
+
+      if (!mongoose.isValidObjectId(itemId)) {
+        return res.status(400).json({ error: "INVALID_ITEM_ID" });
+      }
+      if (!Number.isFinite(y)) {
+        return res.status(400).json({ error: "INVALID_YEAR" });
+      }
+      const amt = Number(amount);
+      if (!Number.isFinite(amt) || amt < 0) {
+        return res.status(400).json({ error: "INVALID_AMOUNT" });
+      }
+
+      // Load item for permission + org boundary
+      const item = await CareNeedItem.findById(itemId).lean();
+      if (!item) return res.status(404).json({ error: "ITEM_NOT_FOUND" });
+
+      // Permission against the item's person
+      const perm = await ensureCanManagePerson(req.user, item.personId);
+      if (!perm.ok) return res.status(403).json({ error: perm.code });
+
+      // org guard (belt-and-suspenders)
+      if (String(item.organizationId) !== String(req.user.organizationId)) {
+        return res.status(403).json({ error: "ORG_SCOPE_INVALID" });
+      }
+
+      // Try update if year already exists
+      const upd = await CareNeedItem.updateOne(
+        { _id: item._id, "budgets.year": y },
+        { $set: { "budgets.$.amount": amt } }
+      );
+
+      if (upd.matchedCount && upd.modifiedCount) {
+        const updated = await CareNeedItem.findById(item._id).lean();
+        return res.json({ ok: true, item: updated });
+      }
+
+      // Else push a new year row (avoid dup years; pre-save guard already exists)
+      const pushRes = await CareNeedItem.findByIdAndUpdate(
+        item._id,
+        { $push: { budgets: { year: y, amount: amt } } },
+        { new: true, runValidators: true }
+      ).lean();
+
+      return res.json({ ok: true, item: pushRes });
+    } catch (e) {
+      res.status(400).json({ error: e.message });
+    }
+  }
+);
 
 export default router;

--- a/server/routes/personWithNeeds.js
+++ b/server/routes/personWithNeeds.js
@@ -76,4 +76,34 @@ router.get("/:id/categories", requireAuth, async (req, res) => {
   }
 });
 
+// PATCH /api/person-with-needs/:personId/budget
+router.patch("/:personId/budget", requireAuth, async (req, res) => {
+  try {
+    const { amount } = req.body || {};
+    const value = Number(amount);
+    if (!Number.isFinite(value) || value < 0) {
+      return res.status(400).json({ error: "INVALID_AMOUNT" });
+    }
+
+    const person = await PersonWithNeeds.findById(req.params.personId);
+    if (!person) return res.status(404).json({ error: "PERSON_NOT_FOUND" });
+
+    // org boundary
+    if (String(person.organizationId) !== String(req.user.organizationId)) {
+      return res.status(403).json({ error: "ORG_SCOPE_INVALID" });
+    }
+
+    person.currentAnnualBudget = value;
+    await person.save();
+
+    res.json({
+      ok: true,
+      personId: String(person._id),
+      currentAnnualBudget: person.currentAnnualBudget,
+    });
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
+});
+
 export default router;

--- a/server/routes/reports.js
+++ b/server/routes/reports.js
@@ -6,26 +6,40 @@ import CareNeedItem from "../models/CareNeedItem.js";
 
 const router = Router();
 
+const NEAR_THRESH = 0.8;
+
+function levelFromRatio(ratio) {
+  if (ratio > 1) return "serious";
+  if (ratio >= NEAR_THRESH) return "light";
+  return null;
+}
+
+function makeWarn(ratio, overMsg, nearMsg) {
+  if (ratio > 1) return { level: "serious", message: overMsg };
+  if (ratio >= NEAR_THRESH) return { level: "light", message: nearMsg };
+  return null;
+}
+
 // GET /api/reports/budget?personId=...&year=2025
 router.get("/budget", requireAuth, async (req, res) => {
   try {
     const { personId, year } = req.query;
     if (!personId || !year)
       return res.status(400).json({ error: "MISSING_PARAMS" });
+
     const y = Number(year);
     const from = new Date(Date.UTC(y, 0, 1));
     const to = new Date(Date.UTC(y + 1, 0, 1));
 
-    // Load person + org guard
+    // Person + org guard
     const person = await Person.findById(personId).lean();
     if (!person) return res.status(404).json({ error: "PERSON_NOT_FOUND" });
     if (String(person.organizationId) !== String(req.user.organizationId)) {
       return res.status(403).json({ error: "ORG_SCOPE_INVALID" });
     }
+    const predefinedAnnualBudget = Number(person.currentAnnualBudget || 0);
 
-    const annualBudget = Number(person.currentAnnualBudget || 0);
-
-    // --- completed spend from CareTask.cost ---
+    // ---------- Top-level spend aggregates (independent from budget source) ----------
     const completedAgg = await CareTask.aggregate([
       {
         $match: {
@@ -40,8 +54,7 @@ router.get("/budget", requireAuth, async (req, res) => {
     ]);
     const completedSpend = completedAgg[0]?.total || 0;
 
-    // expected remaining from uncompleted tasks (join to item.occurrenceCost + category) ---
-    const pendingAgg = await CareTask.aggregate([
+    const expectedAgg = await CareTask.aggregate([
       {
         $match: {
           personId: person._id,
@@ -59,16 +72,10 @@ router.get("/budget", requireAuth, async (req, res) => {
         },
       },
       { $unwind: "$item" },
-      {
-        $group: {
-          _id: null,
-          total: { $sum: "$item.occurrenceCost" },
-        },
-      },
+      { $group: { _id: null, total: { $sum: "$item.occurrenceCost" } } },
     ]);
-    const expectedRemaining = pendingAgg[0]?.total || 0;
+    const expectedRemaining = expectedAgg[0]?.total || 0;
 
-    // --- purchase cost counted in the year items start ---
     const purchaseAgg = await CareNeedItem.aggregate([
       {
         $match: {
@@ -83,12 +90,8 @@ router.get("/budget", requireAuth, async (req, res) => {
     const purchaseSpend = purchaseAgg[0]?.total || 0;
 
     const totalSpent = completedSpend + purchaseSpend;
-    const currentBalance = annualBudget - totalSpent;
-    const expectedBalanceAtYearEnd =
-      annualBudget - totalSpent - expectedRemaining;
 
-    // --- category breakdowns: spent (completed+purchase) and expected ---
-    // completed by category
+    // ---------- Category-level rollups (spent / purchase / expected) ----------
     const completedByCat = await CareTask.aggregate([
       {
         $match: {
@@ -111,7 +114,6 @@ router.get("/budget", requireAuth, async (req, res) => {
       { $group: { _id: "$item.category", spent: { $sum: "$cost" } } },
     ]);
 
-    // purchase by category (items that started this year)
     const purchaseByCat = await CareNeedItem.aggregate([
       {
         $match: {
@@ -124,7 +126,6 @@ router.get("/budget", requireAuth, async (req, res) => {
       { $group: { _id: "$category", purchase: { $sum: "$purchaseCost" } } },
     ]);
 
-    // expected by category (pending tasks)
     const expectedByCat = await CareTask.aggregate([
       {
         $match: {
@@ -151,86 +152,298 @@ router.get("/budget", requireAuth, async (req, res) => {
       },
     ]);
 
-    // category annual budgets (sum of item.budgetCost per category) FOR THE YEAR
-    const catBudgetAgg = await CareNeedItem.aggregate([
-      {
-        $match: {
-          personId: person._id,
-          organizationId: person.organizationId,
-          createdAt: { $gte: from, $lt: to }, // <-- bound to report year
-          budgetCost: { $gt: 0 },
-        },
-      },
-      { $group: { _id: "$category", annualBudget: { $sum: "$budgetCost" } } },
-    ]);
-
-    // merge per-category results
+    // Initialize cats from the three aggregates
     const cats = {};
-    for (const r of completedByCat)
+    for (const r of completedByCat) {
       cats[r._id] = {
         category: r._id,
         spent: r.spent || 0,
         purchase: 0,
         expected: 0,
+        annualBudget: 0,
+        items: [],
       };
-    for (const r of purchaseByCat)
-      (cats[r._id] ||= {
-        category: r._id,
-        spent: 0,
-        purchase: 0,
-        expected: 0,
-      }).purchase = r.purchase || 0;
-    for (const r of expectedByCat)
-      (cats[r._id] ||= {
-        category: r._id,
-        spent: 0,
-        purchase: 0,
-        expected: 0,
-      }).expected = r.expected || 0;
-    for (const r of catBudgetAgg)
+    }
+    for (const r of purchaseByCat) {
       (cats[r._id] ||= {
         category: r._id,
         spent: 0,
         purchase: 0,
         expected: 0,
         annualBudget: 0,
-      }).annualBudget = r.annualBudget || 0;
+        items: [],
+      }).purchase = r.purchase || 0;
+    }
+    for (const r of expectedByCat) {
+      (cats[r._id] ||= {
+        category: r._id,
+        spent: 0,
+        purchase: 0,
+        expected: 0,
+        annualBudget: 0,
+        items: [],
+      }).expected = r.expected || 0;
+    }
 
+    // ---------- Per-item details (year scoped) ----------
+    const completedByItem = await CareTask.aggregate([
+      {
+        $match: {
+          personId: person._id,
+          organizationId: person.organizationId,
+          status: "Completed",
+          dueDate: { $gte: from, $lt: to },
+          cost: { $ne: null },
+        },
+      },
+      { $group: { _id: "$careNeedItemId", completed: { $sum: "$cost" } } },
+    ]);
+
+    const expectedByItem = await CareTask.aggregate([
+      {
+        $match: {
+          personId: person._id,
+          organizationId: person.organizationId,
+          status: { $in: ["Scheduled", "Missed"] },
+          dueDate: { $gte: from, $lt: to },
+        },
+      },
+      {
+        $lookup: {
+          from: "careneeditems",
+          localField: "careNeedItemId",
+          foreignField: "_id",
+          as: "item",
+        },
+      },
+      { $unwind: "$item" },
+      {
+        $group: {
+          _id: "$careNeedItemId",
+          expected: { $sum: "$item.occurrenceCost" },
+        },
+      },
+    ]);
+
+    const purchaseItems = await CareNeedItem.aggregate([
+      {
+        $match: {
+          personId: person._id,
+          organizationId: person.organizationId,
+          "frequency.startDate": { $gte: from, $lt: to },
+          purchaseCost: { $gt: 0 },
+        },
+      },
+      { $project: { _id: 1, purchaseCost: 1, name: 1, category: 1 } },
+    ]);
+
+    const itemIdsFromReport = Array.from(
+      new Set([
+        ...completedByItem.map((r) => String(r._id)),
+        ...expectedByItem.map((r) => String(r._id)),
+        ...purchaseItems.map((r) => String(r._id)),
+      ])
+    );
+
+    let itemsMeta = {};
+    if (itemIdsFromReport.length) {
+      const metas = await CareNeedItem.find(
+        { _id: { $in: itemIdsFromReport } },
+        { _id: 1, name: 1, category: 1, budgets: 1 }
+      ).lean();
+      itemsMeta = Object.fromEntries(metas.map((m) => [String(m._id), m]));
+    }
+
+    const mCompletedByItem = Object.fromEntries(
+      completedByItem.map((r) => [String(r._id), r.completed || 0])
+    );
+    const mExpectedByItem = Object.fromEntries(
+      expectedByItem.map((r) => [String(r._id), r.expected || 0])
+    );
+    const mPurchaseByItem = purchaseItems.reduce((acc, r) => {
+      acc[String(r._id)] = (acc[String(r._id)] || 0) + (r.purchaseCost || 0);
+      return acc;
+    }, {});
+
+    function budgetForYear(metaDoc, yearNumber) {
+      const arr = metaDoc?.budgets || [];
+      const hit = arr.find((b) => Number(b.year) === Number(yearNumber));
+      return hit ? Number(hit.amount || 0) : 0;
+    }
+
+    const warnFor = (budget, spent, expected) => {
+      if (budget > 0) {
+        if (spent > budget)
+          return {
+            level: "serious",
+            code: "over_spent",
+            message: "Already spent exceeds annual budget.",
+          };
+        if (spent + expected > budget)
+          return {
+            level: "medium",
+            code: "projected_over",
+            message: "Projected spend exceeds annual budget.",
+          };
+        if (spent >= 0.8 * budget)
+          return {
+            level: "light",
+            code: "high_spend",
+            message: "≥80% of annual budget already used.",
+          };
+        return null;
+      } else {
+        if (spent > 0 || expected > 0)
+          return {
+            level: "medium",
+            code: "no_budget",
+            message: "No budget set for this year. Please set the budget.",
+          };
+        return null;
+      }
+    };
+
+    const allItemIds = Object.keys({
+      ...mCompletedByItem,
+      ...mExpectedByItem,
+      ...mPurchaseByItem,
+    });
+
+    for (const id of allItemIds) {
+      const meta = itemsMeta[id] || {
+        name: "(Unknown item)",
+        category: "Other",
+        budgets: [],
+      };
+      const category = meta.category || "Other";
+      const annualBudgetItem = budgetForYear(meta, y);
+      const spentItem =
+        Number(mPurchaseByItem[id] || 0) + Number(mCompletedByItem[id] || 0);
+      const expectedItem = Number(mExpectedByItem[id] || 0);
+      const currentBalanceItem = annualBudgetItem - spentItem;
+      const expectedBalanceItem = currentBalanceItem - expectedItem;
+      const warning = warnFor(annualBudgetItem, spentItem, expectedItem);
+
+      (cats[category] ||= {
+        category,
+        spent: 0,
+        purchase: 0,
+        expected: 0,
+        annualBudget: 0,
+        items: [],
+      }).items.push({
+        itemId: id,
+        name: meta.name,
+        annualBudget: annualBudgetItem,
+        alreadySpent: spentItem,
+        currentBalance: currentBalanceItem,
+        expectedRemaining: expectedItem,
+        expectedBalanceAtYearEnd: expectedBalanceItem,
+        warning,
+      });
+    }
+
+    // ---- Build categories with budget = sum of its items' budgets for the year ---
     const categories = Object.values(cats).map((c) => {
-      const totalCatSpent = c.spent + c.purchase;
-      const currentCatBalance = c.annualBudget - totalCatSpent;
-      const expectedCatBalanceAtYearEnd =
-        c.annualBudget - totalCatSpent - c.expected;
+      const annualBudgetFromItems = (c.items || []).reduce(
+        (sum, it) => sum + Number(it.annualBudget || 0),
+        0
+      );
+      c.annualBudget = annualBudgetFromItems;
 
-      // keep existing percentage columns (optional)
+      const totalCatSpent = (c.spent || 0) + (c.purchase || 0);
+      const currentCatBalance = (c.annualBudget || 0) - totalCatSpent;
+      const expectedCatBalanceAtYearEnd =
+        (c.annualBudget || 0) - totalCatSpent - (c.expected || 0);
+
       const spentPct = totalSpent > 0 ? totalCatSpent / totalSpent : 0;
       const expectedPct =
-        expectedRemaining > 0 ? c.expected / expectedRemaining : 0;
+        expectedRemaining > 0 ? (c.expected || 0) / expectedRemaining : 0;
+
+      const rank = { serious: 3, medium: 2, light: 1 };
+      (c.items || []).sort((a, b) => {
+        const ra = a.warning ? rank[a.warning.level] || 0 : 0;
+        const rb = b.warning ? rank[b.warning.level] || 0 : 0;
+        if (rb !== ra) return rb - ra;
+        const oa = a.alreadySpent + a.expectedRemaining - a.annualBudget;
+        const ob = b.alreadySpent + b.expectedRemaining - b.annualBudget;
+        return (ob || 0) - (oa || 0);
+      });
 
       return {
         category: c.category,
-        annualBudget: c.annualBudget,
+        annualBudget: c.annualBudget || 0,
         totalSpent: totalCatSpent,
         currentBalance: currentCatBalance,
-        expected: c.expected,
+        expected: c.expected || 0,
         expectedBalanceAtYearEnd: expectedCatBalanceAtYearEnd,
         spentPct,
         expectedPct,
+        items: c.items || [],
       };
     });
+
+    // Report-level annual budget from categories
+    const reportAnnualBudget = categories.reduce(
+      (sum, cat) => sum + Number(cat.annualBudget || 0),
+      0
+    );
+
+    // compute balances using the reportAnnualBudget
+    const currentBalance = reportAnnualBudget - totalSpent;
+    const expectedBalanceAtYearEnd =
+      reportAnnualBudget - totalSpent - expectedRemaining;
+
+    // ---------- NEW: top-level warnings ----------
+    const warnings = {
+      budgetVsPredefined: null,
+      spentVsReportBudget: null,
+      projectedVsReportBudget: null,
+    };
+
+    // Sum-of-categories vs predefined person budget
+    if (predefinedAnnualBudget > 0) {
+      const ratio = reportAnnualBudget / predefinedAnnualBudget;
+      const w = makeWarn(
+        ratio,
+        "Total of category budgets exceeds the client's predefined annual budget.",
+        "Total of category budgets is ≥80% of the client's predefined annual budget."
+      );
+      if (w) warnings.budgetVsPredefined = w;
+    }
+
+    // Already spent vs report budget (sum of categories)
+    if (reportAnnualBudget > 0) {
+      const ratioSpent = totalSpent / reportAnnualBudget;
+      const wSpent = makeWarn(
+        ratioSpent,
+        "Already spent exceeds the total categories annual budget.",
+        "Already spent is ≥80% of the total categories annual budget."
+      );
+      if (wSpent) warnings.spentVsReportBudget = wSpent;
+
+      // Projected (spent + expected) vs report budget
+      const ratioProj = (totalSpent + expectedRemaining) / reportAnnualBudget;
+      const wProj = makeWarn(
+        ratioProj,
+        "Projected spend (spent + expected) exceeds the total categories annual budget.",
+        "Projected spend is ≥80% of the total categories annual budget."
+      );
+      if (wProj) warnings.projectedVsReportBudget = wProj;
+    }
 
     res.json({
       personId,
       year: y,
-      annualBudget,
+      annualBudget: reportAnnualBudget,
+      predefinedAnnualBudget,
+      warnings,
       spent: {
         purchase: purchaseSpend,
         completed: completedSpend,
         total: totalSpent,
       },
-      expected: {
-        remaining: expectedRemaining,
-      },
+      expected: { remaining: expectedRemaining },
       balance: {
         current: currentBalance,
         expectedAtYearEnd: expectedBalanceAtYearEnd,


### PR DESCRIPTION
added table-like format for budget report. It shows details (annual budget, spent, balance) for each care need item/sub-element, then grouped by categories (sum of care need items), then group by client (sum of categores), with warnings for 80% and 100% threhold. Also added functionality to allocate and change budget of a care need item, and between care need item (same category / difference categories)